### PR TITLE
Feature/bottom modal UI

### DIFF
--- a/ADA-C2-Helping.xcodeproj/xcuserdata/donggyunyang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ADA-C2-Helping.xcodeproj/xcuserdata/donggyunyang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -7,22 +7,6 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "24927583-F239-4BB7-B2B8-199E226F719E"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "10"
-            endingLineNumber = "10"
-            landmarkName = "CardHeader"
-            landmarkType = "14">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
             uuid = "03364AD2-E3A8-47E4-A6E3-B79415EBA8DF"
             shouldBeEnabled = "No"
             ignoreCount = "0"
@@ -30,89 +14,9 @@
             filePath = "ADA-C2-Helping/Views/Common/Card.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "58"
-            endingLineNumber = "58"
+            startingLineNumber = "41"
+            endingLineNumber = "41"
             landmarkName = "CardModel"
-            landmarkType = "14">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "A492AD13-3EF0-44DD-9B9B-05A34F12F1B3"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "11"
-            endingLineNumber = "11"
-            landmarkName = "CardHeader"
-            landmarkType = "14">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "7C692425-6702-4B24-80F7-6601A403F1D7"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "13"
-            endingLineNumber = "13"
-            landmarkName = "init(_:)"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "0503D605-7711-4840-96FF-D476E19EBB7F"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "15"
-            endingLineNumber = "15"
-            landmarkName = "init(_:)"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "6FCAEAE3-5497-4CAF-A3F5-B3444F563CF1"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "12"
-            endingLineNumber = "12"
-            landmarkName = "CardHeader"
-            landmarkType = "14">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "63A5CA21-7ECA-437E-9594-B495F4211D69"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "16"
-            endingLineNumber = "16"
-            landmarkName = "CardHeader"
             landmarkType = "14">
          </BreakpointContent>
       </BreakpointProxy>

--- a/ADA-C2-Helping.xcodeproj/xcuserdata/donggyunyang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ADA-C2-Helping.xcodeproj/xcuserdata/donggyunyang.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "DD7545A3-05EC-4ED9-89FE-EA1AAE32B2E7"
    type = "1"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "03364AD2-E3A8-47E4-A6E3-B79415EBA8DF"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ADA-C2-Helping/Views/Common/Card.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "41"
-            endingLineNumber = "41"
-            landmarkName = "CardModel"
-            landmarkType = "14">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/ADA-C2-Helping/Assets.xcassets/CustomGray.colorset/Contents.json
+++ b/ADA-C2-Helping/Assets.xcassets/CustomGray.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x87",
-          "green" : "0x87",
-          "red" : "0x87"
+          "blue" : "0xB5",
+          "green" : "0xB5",
+          "red" : "0xB5"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -34,8 +34,5 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
-  },
-  "properties" : {
-    "localizable" : true
   }
 }

--- a/ADA-C2-Helping/Assets.xcassets/Gray666.colorset/Contents.json
+++ b/ADA-C2-Helping/Assets.xcassets/Gray666.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x66",
+          "red" : "0x66"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ADA-C2-Helping/Assets.xcassets/emptyColor.colorset/Contents.json
+++ b/ADA-C2-Helping/Assets.xcassets/emptyColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xF3",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ADA-C2-Helping/Models/DataType.swift
+++ b/ADA-C2-Helping/Models/DataType.swift
@@ -1,0 +1,7 @@
+//
+//  DataType.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/16/25.
+//
+

--- a/ADA-C2-Helping/Models/MajorType.swift
+++ b/ADA-C2-Helping/Models/MajorType.swift
@@ -1,0 +1,28 @@
+//
+//  MajorType.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/16/25.
+//
+import SwiftUI
+
+enum MajorType: String, CaseIterable, Identifiable {
+    case tech = "Tech"
+    case design = "Design"
+    case domain = "Domain"
+    
+    var id: String {
+        self.rawValue;
+    }
+    
+    var color: Color {
+        switch self {
+        case .tech:
+            return .accentColor
+        case .design:
+            return Color("DesignColor")
+        case .domain:
+            return Color("DomainColor")
+        }
+    }
+}

--- a/ADA-C2-Helping/Views/Common/Card.swift
+++ b/ADA-C2-Helping/Views/Common/Card.swift
@@ -22,23 +22,6 @@ struct CardHeader: View {
     }
 }
 
-enum MajorType: String {
-    case tech = "Tech"
-    case design = "Design"
-    case domain = "Domain"
-    
-    var color: Color {
-        switch self {
-        case .tech:
-            return .accentColor
-        case .design:
-            return Color("DesignColor")
-        case .domain:
-            return Color("DomainColor")
-        }
-    }
-}
-
 struct CardFooter: View {
     let name: String
     let major: MajorType

--- a/ADA-C2-Helping/Views/Common/Card.swift
+++ b/ADA-C2-Helping/Views/Common/Card.swift
@@ -38,9 +38,10 @@ struct CardFooter: View {
     }
 }
 
-struct CardModel: Identifiable {
+struct CardModel: Identifiable, Hashable {
     let id = UUID()
     let image: String = "default-card"
+    let title: String
     let text: String
     let name: String
     let major: MajorType
@@ -57,7 +58,7 @@ struct Card: View {
                 .frame(width: 32, height: 32)
             
             VStack(alignment: .leading, spacing: 6) {
-                CardHeader(model.text)
+                CardHeader(model.title)
                 
                 CardFooter(name: model.name, major: model.major)
             }
@@ -70,8 +71,4 @@ struct Card: View {
                 .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
         )
     }
-}
-
-#Preview {
-    Card(model: CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .tech))
 }

--- a/ADA-C2-Helping/Views/Common/CardList.swift
+++ b/ADA-C2-Helping/Views/Common/CardList.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct CardList: View {
-    var cardModels: [CardModel]
+    @Binding var cards: [CardModel]
+    @Binding var selectedCard: CardModel?
     
     var body: some View {
         VStack { // Todo Scroll View
             List {
                 Section(footer: Spacer().frame(height: 80)) {
-                    ForEach(cardModels) { model in
-                        Card(model: model)
+                    ForEach(cards) { card in
+                        Card(model: card)
                             .resetRowStyle(
                                 top: 6, leading: 16, bottom: 12, trailing: 16
                             )
@@ -25,8 +26,11 @@ struct CardList: View {
                                 } label: { Label("Delete", systemImage: "trash") }
                                 
                                 Button {
-                                        
+                                    
                                 } label: { Label("Flag", systemImage: "flag") }
+                            }
+                            .onTapGesture {
+                                selectedCard = card
                             }
                     }
                 }
@@ -35,19 +39,4 @@ struct CardList: View {
             .listStyle(.plain)
         }
     }
-}
-
-#Preview {
-    let testDatas: [CardModel] = [
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .tech),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .design),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .domain),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .tech),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .design),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .domain),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .tech),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .design),
-        CardModel(text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!!", name: "pray", major: .domain)
-    ]
-    CardList(cardModels: testDatas)
 }

--- a/ADA-C2-Helping/Views/Common/CustomButton.swift
+++ b/ADA-C2-Helping/Views/Common/CustomButton.swift
@@ -19,11 +19,11 @@ struct CustomButton: View {
                     , NotoSansStyle(fontStyle: .medium, size: 17, color: .white
                     )
                 )
+                .padding(.vertical, 18)
+                .frame(maxWidth: .infinity)
+                .background(.accent, in: RoundedRectangle(cornerRadius: 12))
+                .shadow(color: Color.black.opacity(0.1), radius: 6, x: 0, y: 2)
             }
-            .padding(.vertical, 18)
-            .frame(maxWidth: .infinity)
-            .background(.accent, in: RoundedRectangle(cornerRadius: 12))
-            .shadow(color: Color.black.opacity(0.1), radius: 6, x: 0, y: 2)
         }
     }
 }

--- a/ADA-C2-Helping/Views/Common/CustomButton.swift
+++ b/ADA-C2-Helping/Views/Common/CustomButton.swift
@@ -1,0 +1,36 @@
+//
+//  Button.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/16/25.
+//
+
+import SwiftUI
+
+struct CustomButton: View {
+    let text: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack {
+            Button(action: action) {
+                NotoSansText(
+                    text
+                    , NotoSansStyle(fontStyle: .medium, size: 17, color: .white
+                    )
+                )
+            }
+            .padding(.vertical, 18)
+            .frame(maxWidth: .infinity)
+            .background(.accent, in: RoundedRectangle(cornerRadius: 12))
+            .shadow(color: Color.black.opacity(0.1), radius: 6, x: 0, y: 2)
+        }
+    }
+}
+
+#Preview {
+    CustomButton(text: "글 작성하기") {
+            
+    }
+    .padding(.horizontal, 30)
+}

--- a/ADA-C2-Helping/Views/Common/CustomSegmentedPicker.swift
+++ b/ADA-C2-Helping/Views/Common/CustomSegmentedPicker.swift
@@ -1,0 +1,59 @@
+//
+//  CustomSegmentedPicker.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/16/25.
+//
+
+import SwiftUI
+
+struct CustomSegmentedPicker: View {
+    var datas: [MajorType]
+    @Binding var selectedData: String
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(datas, id: \.self) { data in
+                Button {
+                    selectedData = data.rawValue
+                } label: {
+                    NotoSansText(
+                        data.rawValue,
+                        NotoSansStyle(
+                            fontStyle: .medium
+                            , size: 15
+                            , color: data.rawValue == selectedData
+                                        ? .white
+                                        : .gray666
+                        )
+                    )
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(
+                        data.rawValue == selectedData
+                        ? data.color
+                        : Color.clear
+                    )
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.empty, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct CustomSegmentedPicker_Previews: View {
+    @State private var selectedData: String = MajorType.allCases.first?.rawValue ?? ""
+
+    var body: some View {
+        CustomSegmentedPicker(
+            datas: MajorType.allCases,
+            selectedData: $selectedData
+        )
+        .padding(.horizontal, 50)
+    }
+}
+
+#Preview {
+    CustomSegmentedPicker_Previews()
+}

--- a/ADA-C2-Helping/Views/Common/Header.swift
+++ b/ADA-C2-Helping/Views/Common/Header.swift
@@ -8,17 +8,20 @@
 import SwiftUI
 
 struct Header: View {
+    @Binding var cards: [CardModel]
+    
     var body: some View {
         HStack {
             Image("logo")
             
             Spacer()
             
-            Image("list-bullet")
+            NavigationLink {
+                MyView(cards: $cards)
+                    .navigationTitle("나의 기록")
+            } label: {
+                Image("list-bullet")
+            }
         }
     }
-}
-
-#Preview {
-    Header()
 }

--- a/ADA-C2-Helping/Views/Common/Header.swift
+++ b/ADA-C2-Helping/Views/Common/Header.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct Header: View {
     @Binding var cards: [CardModel]
+    @Binding var selectedCard: CardModel?
     
     var body: some View {
         HStack {
@@ -17,7 +18,7 @@ struct Header: View {
             Spacer()
             
             NavigationLink {
-                MyView(cards: $cards)
+                MyView(cards: $cards, selectedCard: $selectedCard)
                     .navigationTitle("나의 기록")
             } label: {
                 Image("list-bullet")

--- a/ADA-C2-Helping/Views/Common/MajorSegmentedPicker.swift
+++ b/ADA-C2-Helping/Views/Common/MajorSegmentedPicker.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct CustomSegmentedPicker: View {
+struct MajorSegmentedPicker: View {
     var datas: [MajorType]
     @Binding var selectedData: String
     
@@ -46,7 +46,7 @@ struct CustomSegmentedPicker_Previews: View {
     @State private var selectedData: String = MajorType.allCases.first?.rawValue ?? ""
 
     var body: some View {
-        CustomSegmentedPicker(
+        MajorSegmentedPicker(
             datas: MajorType.allCases,
             selectedData: $selectedData
         )

--- a/ADA-C2-Helping/Views/CreateHelpView.swift
+++ b/ADA-C2-Helping/Views/CreateHelpView.swift
@@ -1,0 +1,49 @@
+//
+//  CreateHelpView.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/16/25.
+//
+
+import SwiftUI
+
+struct CreateHelpView: View {
+    @State private var selectedMajor: MajorType = .tech
+    
+    var body: some View {
+        VStack {
+            // TODO: 요청 분야
+            VStack(alignment: .leading) {
+                // Title
+                NotoSansText(
+                    "요청 분야",
+                    NotoSansStyle(fontStyle: .medium, size: 13, color: Color.gray666)
+                )
+                
+                // Content
+                Picker("", selection: $selectedMajor) {
+                    ForEach(MajorType.allCases) { major in
+                        NotoSansText(
+                            major.rawValue,
+                            NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
+                        ).tag(major)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .foregroundStyle(Color.accentColor)
+            }
+            .frame(maxWidth: .infinity)
+            
+            // TODO: 제목
+            
+            // TODO: 내용
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(24)
+        .border(.red, width: 2)
+    }
+}
+
+#Preview {
+    CreateHelpView()
+}

--- a/ADA-C2-Helping/Views/CreateHelpView.swift
+++ b/ADA-C2-Helping/Views/CreateHelpView.swift
@@ -8,39 +8,79 @@
 import SwiftUI
 
 struct CreateHelpView: View {
-    @State private var selectedMajor: MajorType = .tech
+    @State private var selectedMajor: String = MajorType.tech.rawValue
+    @State private var title: String = ""
+    @State private var content: String = ""
     
     var body: some View {
-        VStack {
-            // TODO: 요청 분야
+        VStack(spacing: 16) {
+            // 요청 분야
             VStack(alignment: .leading) {
                 // Title
                 NotoSansText(
                     "요청 분야",
-                    NotoSansStyle(fontStyle: .medium, size: 13, color: Color.gray666)
+                    NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
                 )
                 
                 // Content
-                Picker("", selection: $selectedMajor) {
-                    ForEach(MajorType.allCases) { major in
+                MajorSegmentedPicker(datas: MajorType.allCases, selectedData: $selectedMajor)
+            }
+            
+            // 제목
+            VStack(alignment: .leading) {
+                // Title
+                NotoSansText(
+                    "제목",
+                    NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
+                )
+                
+                // Content
+                TextField(
+                    "제목을 입력하세요",
+                    text: $title
+                )
+                .font(.custom("NotoSansKR-Regular", size: 17))
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(.empty, in: RoundedRectangle(cornerRadius: 8))
+            }
+            
+            // 내용
+            VStack(alignment: .leading) {
+                // Title
+                NotoSansText(
+                    "내용",
+                    NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
+                )
+                
+                // Content
+                ZStack(alignment: .topLeading) {
+                    TextEditor(
+                        text: $content
+                    )
+                    .font(.custom("NotoSansKR-Regular", size: 17))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(.empty, in: RoundedRectangle(cornerRadius: 8))
+                    .scrollContentBackground(.hidden)
+                    
+                    if(content.isEmpty) {
                         NotoSansText(
-                            major.rawValue,
-                            NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
-                        ).tag(major)
+                            "내용을 입력하세요"
+                            , NotoSansStyle(fontStyle: .regular, size: 17, color: Color.gray.opacity(0.5))
+                        )
+                        .padding(.horizontal, 19)
+                        .padding(.vertical, 20)
                     }
                 }
-                .pickerStyle(.segmented)
-                .foregroundStyle(Color.accentColor)
             }
-            .frame(maxWidth: .infinity)
             
-            // TODO: 제목
-            
-            // TODO: 내용
+            CustomButton(text: "글 작성하기") {
+                
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(24)
-        .border(.red, width: 2)
     }
 }
 

--- a/ADA-C2-Helping/Views/CreateHelpView.swift
+++ b/ADA-C2-Helping/Views/CreateHelpView.swift
@@ -7,6 +7,29 @@
 
 import SwiftUI
 
+struct FormSection<Content: View>: View {
+    let title: String
+    let content: () -> Content
+    
+    init(_ title: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title;
+        self.content = content
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            // Title
+            NotoSansText(
+                title,
+                NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
+            )
+            
+            // Content
+            content()
+        }
+    }
+}
+
 struct CreateHelpView: View {
     @State private var selectedMajor: String = MajorType.tech.rawValue
     @State private var title: String = ""
@@ -15,26 +38,12 @@ struct CreateHelpView: View {
     var body: some View {
         VStack(spacing: 16) {
             // 요청 분야
-            VStack(alignment: .leading) {
-                // Title
-                NotoSansText(
-                    "요청 분야",
-                    NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
-                )
-                
-                // Content
+            FormSection("요청 분야") {
                 MajorSegmentedPicker(datas: MajorType.allCases, selectedData: $selectedMajor)
             }
             
             // 제목
-            VStack(alignment: .leading) {
-                // Title
-                NotoSansText(
-                    "제목",
-                    NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
-                )
-                
-                // Content
+            FormSection("제목") {
                 TextField(
                     "제목을 입력하세요",
                     text: $title
@@ -46,14 +55,7 @@ struct CreateHelpView: View {
             }
             
             // 내용
-            VStack(alignment: .leading) {
-                // Title
-                NotoSansText(
-                    "내용",
-                    NotoSansStyle(fontStyle: .medium, size: 15, color: Color.gray666)
-                )
-                
-                // Content
+            FormSection("내용") {
                 ZStack(alignment: .topLeading) {
                     TextEditor(
                         text: $content

--- a/ADA-C2-Helping/Views/DetailView.swift
+++ b/ADA-C2-Helping/Views/DetailView.swift
@@ -1,0 +1,64 @@
+//
+//  DetailView.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/17/25.
+//
+
+import SwiftUI
+
+struct DetailView: View {
+    
+    var content: CardModel
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // TODO: Profile
+            HStack() {
+                // Image
+                Image(content.image)
+                    .resizable()
+                    .frame(width: 64, height: 64)
+                    .aspectRatio(contentMode: .fit)
+                
+                VStack(alignment: .leading, spacing: 10) {
+                    // nickname
+                    NotoSansText(
+                        "닉네임: \(content.name)"
+                        , NotoSansStyle(size: 14)
+                    )
+                    
+                    // major
+                    NotoSansText(
+                        "도움 요청 분야: \(content.major)"
+                        , NotoSansStyle(size: 14)
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            // TODO: Content
+            VStack(alignment: .leading, spacing: 12) {
+                // title
+                NotoSansText(
+                    content.title
+                    , NotoSansStyle(fontStyle: .bold, size: 20)
+                )
+                
+                // content
+                NotoSansText(
+                    content.text
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            Spacer()
+            
+            CustomButton(text: "도움 주기") {
+                
+            }
+        }
+        .padding(.top, 24)
+        .padding(.horizontal, 16)
+    }
+}

--- a/ADA-C2-Helping/Views/Home/HomeView.swift
+++ b/ADA-C2-Helping/Views/Home/HomeView.swift
@@ -10,16 +10,14 @@ import SwiftUI
 struct FAB: View {
     var body: some View {
         VStack {
-            HStack {
-                // Button
-                Button {
-                    
-                } label: {
-                    Image(systemName: "plus")
-                }
-                .foregroundStyle(.white)
-                .font(.system(size: 30))
+            // Button
+            Button {
+                
+            } label: {
+                Image(systemName: "plus")
             }
+            .foregroundStyle(.white)
+            .font(.system(size: 30))
             .frame(width: 80, height: 80)
             .background(.accent, in: RoundedRectangle(cornerRadius: 50))
         }

--- a/ADA-C2-Helping/Views/Home/HomeView.swift
+++ b/ADA-C2-Helping/Views/Home/HomeView.swift
@@ -7,8 +7,58 @@
 
 import SwiftUI
 
+struct FAB: View {
+    var body: some View {
+        VStack {
+            HStack {
+                // Button
+                Button {
+                    
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .foregroundStyle(.white)
+                .font(.system(size: 30))
+            }
+            .frame(width: 80, height: 80)
+            .background(.accent, in: RoundedRectangle(cornerRadius: 50))
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.top, 16)
+        .background(
+            LinearGradient(colors: [Color.white.opacity(0), .white], startPoint: .top, endPoint: UnitPoint(x: 0.5, y: 0.75))
+        )
+    }
+}
+
+struct ListContent: View {
+    var cards: [CardModel]
+    
+    init(_ cards: [CardModel]) {
+        self.cards = cards
+    }
+    
+    var body: some View {
+        VStack {
+            HStack {
+                NotoSansText("도움이 필요해요", NotoSansStyle(
+                    fontStyle: .bold, size: 28
+                ))
+                Spacer()
+                NotoSansText("32", NotoSansStyle(
+                    fontStyle: .bold, size: 16, color: .accent
+                ))
+            }
+            .padding(.horizontal, 16)
+            
+            CardList(cardModels: cards)
+        }
+        
+    }
+}
+
 struct HomeView: View {
-    let cards: [CardModel];
+    let cards: [CardModel]
     
     var body: some View {
         VStack {
@@ -17,42 +67,9 @@ struct HomeView: View {
                 .padding(.horizontal, 16)
             
             ZStack(alignment: .bottom) {
-                // Todo: Content
-                VStack {
-                    HStack {
-                        NotoSansText("도움이 필요해요", NotoSansStyle(
-                            fontStyle: .bold, size: 28
-                        ))
-                        Spacer()
-                        NotoSansText("32", NotoSansStyle(
-                            fontStyle: .bold, size: 16, color: .accent
-                        ))
-                    }
-                    .padding(.horizontal, 16)
-                    
-                    CardList(cardModels: cards)
-                }
+                ListContent(cards)
                 
-                // Todo: FAB
-                VStack {
-                    HStack {
-                        // Button
-                        Button {
-                            
-                        } label: {
-                            Image(systemName: "plus")
-                        }
-                        .foregroundStyle(.white)
-                        .font(.system(size: 30))
-                    }
-                    .frame(width: 80, height: 80)
-                    .background(.accent, in: RoundedRectangle(cornerRadius: 50))
-                }
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.top, 16)
-                .background(
-                    LinearGradient(colors: [Color.white.opacity(0), .white], startPoint: .top, endPoint: UnitPoint(x: 0.5, y: 0.75))
-                )
+                FAB()
             }
         }
     }

--- a/ADA-C2-Helping/Views/HomeView.swift
+++ b/ADA-C2-Helping/Views/HomeView.swift
@@ -24,8 +24,8 @@ struct FAB: View {
             .frame(width: 80, height: 80)
             .background(.accent, in: RoundedRectangle(cornerRadius: 50))
             .sheet(isPresented: $showSheet) {
-                // TODO: add CreateHelpView
                 CreateHelpView()
+                    .presentationDragIndicator(.visible)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
@@ -63,25 +63,9 @@ struct ListContent: View {
 }
 
 struct HomeView: View {
-    let cards: [CardModel]
     
-    var body: some View {
-        VStack {
-            Header()
-                .padding(.bottom, 24)
-                .padding(.horizontal, 16)
-            
-            ZStack(alignment: .bottom) {
-                ListContent(cards)
-                
-                FAB()
-            }
-        }
-    }
-}
-
-#Preview {
-    let testDatas = [MajorType.tech, .design, .domain].flatMap { majorType in
+    // TODO: 테스트 데이터 수정 예정
+    @State private var cards: [CardModel]  = [MajorType.tech, .design, .domain].flatMap { majorType in
         (0..<3).map { i in
             CardModel(
                 text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!! 예시 \(i+1)",
@@ -91,5 +75,23 @@ struct HomeView: View {
         }
     }
     
-    HomeView(cards: testDatas)
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Header(cards: $cards)
+                    .padding(.bottom, 24)
+                    .padding(.horizontal, 16)
+                
+                ZStack(alignment: .bottom) {
+                    ListContent(cards)
+                    
+                    FAB()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    HomeView()
 }

--- a/ADA-C2-Helping/Views/HomeView.swift
+++ b/ADA-C2-Helping/Views/HomeView.swift
@@ -14,7 +14,7 @@ struct FAB: View {
         VStack {
             // Button
             Button {
-                
+        
                 showSheet = true
             } label: {
                 Image(systemName: "plus")
@@ -37,11 +37,8 @@ struct FAB: View {
 }
 
 struct ListContent: View {
-    var cards: [CardModel]
-    
-    init(_ cards: [CardModel]) {
-        self.cards = cards
-    }
+    @Binding var cards: [CardModel]
+    @Binding var selectedCard: CardModel?
     
     var body: some View {
         VStack {
@@ -56,7 +53,7 @@ struct ListContent: View {
             }
             .padding(.horizontal, 16)
             
-            CardList(cardModels: cards)
+            CardList(cards: $cards, selectedCard: $selectedCard)
         }
         
     }
@@ -68,25 +65,31 @@ struct HomeView: View {
     @State private var cards: [CardModel]  = [MajorType.tech, .design, .domain].flatMap { majorType in
         (0..<3).map { i in
             CardModel(
-                text: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!! 예시 \(i+1)",
+                title: "나는 이런 도움이 필요해요. 근데 혼자서 해보려니까 잘 되지 않아요... 누가 좀 도와주세요!!! 예시 \(i+1)",
+                text: "지금 SwiftUI로 앱 개발을 처음 해보고 있어요. 유튜브랑 블로그 참고하면서 열심히 해보고 있는데, 막상 네비게이션 연결이나 뷰 전환 같은 기본적인 것들도 막히네요 ㅠㅠ 계속 혼자 고민하다가 지치기도 하고… 혹시 저처럼 처음 시작했을 때 어떻게 극복하셨는지, 팁이나 도와주실 수 있는 분 계실까요?",
                 name: "user\(i+1)",
                 major: majorType
             )
         }
     }
+    @State private var selectedCard: CardModel?
     
     var body: some View {
         NavigationStack {
             VStack {
-                Header(cards: $cards)
+                Header(cards: $cards, selectedCard: $selectedCard)
                     .padding(.bottom, 24)
                     .padding(.horizontal, 16)
                 
                 ZStack(alignment: .bottom) {
-                    ListContent(cards)
+                    ListContent(cards: $cards, selectedCard: $selectedCard)
                     
                     FAB()
                 }
+            }
+            .navigationDestination(item: $selectedCard) { card in
+                DetailView(content: card)
+                    .navigationTitle("도움이 필요해핑!")
             }
         }
     }

--- a/ADA-C2-Helping/Views/HomeView.swift
+++ b/ADA-C2-Helping/Views/HomeView.swift
@@ -8,11 +8,14 @@
 import SwiftUI
 
 struct FAB: View {
+    @State private var showSheet = false
+    
     var body: some View {
         VStack {
             // Button
             Button {
                 
+                showSheet = true
             } label: {
                 Image(systemName: "plus")
             }
@@ -20,6 +23,10 @@ struct FAB: View {
             .font(.system(size: 30))
             .frame(width: 80, height: 80)
             .background(.accent, in: RoundedRectangle(cornerRadius: 50))
+            .sheet(isPresented: $showSheet) {
+                // TODO: add CreateHelpView
+                CreateHelpView()
+            }
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, 16)

--- a/ADA-C2-Helping/Views/MyView.swift
+++ b/ADA-C2-Helping/Views/MyView.swift
@@ -62,16 +62,16 @@ struct Tab: View {
 
 struct MyView: View {
     @State private var tabMode: TabMode = .myHelp
+    
     @Binding var cards: [CardModel]
+    @Binding var selectedCard: CardModel?
     
     var body: some View {
         VStack {
-            // TODO: Tab
             Tab(tabMode: $tabMode)
                 .padding(.top, 24)
             
-            // TODO: List
-            CardList(cardModels: cards)
+            CardList(cards: $cards, selectedCard: $selectedCard)
         }
         .padding(.horizontal, 16)
     }

--- a/ADA-C2-Helping/Views/MyView.swift
+++ b/ADA-C2-Helping/Views/MyView.swift
@@ -1,0 +1,18 @@
+//
+//  MyView.swift
+//  ADA-C2-Helping
+//
+//  Created by Donggyun Yang on 4/17/25.
+//
+
+import SwiftUI
+
+struct MyView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    MyView()
+}

--- a/ADA-C2-Helping/Views/MyView.swift
+++ b/ADA-C2-Helping/Views/MyView.swift
@@ -7,12 +7,72 @@
 
 import SwiftUI
 
-struct MyView: View {
+enum TabMode {
+    case myHelp
+    case giveHelp
+}
+
+struct Tab: View {
+    @Binding var tabMode: TabMode
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        HStack() {
+            Button {
+                tabMode = .myHelp
+            } label: {
+                NotoSansText(
+                    "내가 작성한 글"
+                    , NotoSansStyle(fontStyle: .bold, size: 17, color: tabMode == .myHelp ? .black : .customGray)
+                )
+                .background(
+                    tabMode == .myHelp ?
+                        GeometryReader { geometry in
+                            Rectangle()
+                                .fill(.accent)
+                                .frame(width: geometry.size.width, height: 2)
+                                .offset(y: geometry.size.height + 4)
+                        } : nil
+                )
+            }
+            .frame(maxWidth: 180)
+            
+            Spacer()
+            
+            Button {
+                tabMode = .giveHelp
+            } label: {
+                NotoSansText(
+                    "도움을 주고 있어요"
+                    , NotoSansStyle(fontStyle: .bold, size: 17, color: tabMode == .giveHelp ? .black : .customGray)
+                )
+                .background(
+                    tabMode == .giveHelp ?
+                        GeometryReader { geometry in
+                            Rectangle()
+                                .fill(.accent)
+                                .frame(width: geometry.size.width, height: 2)
+                                .offset(y: geometry.size.height + 4)
+                        } : nil
+                )
+            }
+            .frame(maxWidth: 180)
+        }
     }
 }
 
-#Preview {
-    MyView()
+struct MyView: View {
+    @State private var tabMode: TabMode = .myHelp
+    @Binding var cards: [CardModel]
+    
+    var body: some View {
+        VStack {
+            // TODO: Tab
+            Tab(tabMode: $tabMode)
+                .padding(.top, 24)
+            
+            // TODO: List
+            CardList(cardModels: cards)
+        }
+        .padding(.horizontal, 16)
+    }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
- 글을 작성하는 Bottom Sheet UI 구현
- My View UI 구현
- Detail View UI 구현

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
### Bottom Sheet
<img width="221" alt="image" src="https://github.com/user-attachments/assets/ae207a11-81f5-4630-8f5d-aec830f61138" />


### My View
<img width="226" alt="image" src="https://github.com/user-attachments/assets/bc74e786-d4ce-4cad-9ca7-af3014dc22df" />

### Detail View
<img width="226" alt="image" src="https://github.com/user-attachments/assets/b064ce55-437a-4aa1-a650-ad23588f1647" />


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
1. NavigationStack과 .navigationDestination을 잘 사용한건지 궁금해요... 깔끔하게 코딩하기 위해서 NavigationStack 최상단에 navigation의 destination을 관리해야 한다고 생각이 드니 Prop Drilling이 발생해서 별로인 것 같은데... 어떻게 생각하시나요? 조언이 필요합니다!

```
struct HomeView: View {
    
    // TODO: 테스트 데이터 수정 예정
    @State private var cards: [CardModel]  = /.../

    @State private var selectedCard: CardModel?
    
    var body: some View {
        NavigationStack {
            VStack {
                Header(cards: $cards, selectedCard: $selectedCard)
                    .padding(.bottom, 24)
                    .padding(.horizontal, 16)
                
                ZStack(alignment: .bottom) {
                    ListContent(cards: $cards, selectedCard: $selectedCard)
                    
                    FAB()
                }
            }
            .navigationDestination(item: $selectedCard) { card in
                DetailView(content: card)
                    .navigationTitle("도움이 필요해핑!")
            }
        }
    }
}
```


위 코드를 보면 저 selectedCard 변수가 컴포넌트를 타고타고 밑으로 계속 propsDrilling이 발생하는 상황인데.. 차라리 navigationDestination을 최상단에서 사용하지 말고 밑으로 내리는게 좋을까요?


